### PR TITLE
client: Accept http.Client instead of interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 BINARY := elasticsearch-cli
 AUTHOR = marclop
-VERSION ?= 0.2.0
+VERSION ?= 0.3.0
 INSTALL_PATH ?= $(GOPATH)/bin
 # Test all major version of ES
 ES_VERSION ?= 1.7 2.4 5.4 5.5 5.6
@@ -133,7 +133,7 @@ lint: deps
 .PHONY: acc
 acc: start_elasticsearch_docker
 	@ echo "-> Running acceptance tests for $(BINARY) in Elasticsearch $(ES_VERSION)..."
-	@ go test -tags acceptance . || (echo "-> Killing Docker container $$( docker kill $(ES_CONTAINER_NAME)_$(ES_VERSION) )" && exit 1) \
+	@ go test -tags acceptance -count 1 . || (echo "-> Killing Docker container $$( docker kill $(ES_CONTAINER_NAME)_$(ES_VERSION) )" && exit 1) \
 	&& (echo "-> Killing Docker container $$(docker kill $(ES_CONTAINER_NAME)_$(ES_VERSION))")
 
 .PHONY: start_elasticsearch_docker

--- a/app/app.go
+++ b/app/app.go
@@ -72,7 +72,7 @@ func New(config *Config) (*Application, error) {
 		}
 	}
 
-	httpClient := client.NewHTTP(clientConfig, nil)
+	httpClient := client.NewHTTP(clientConfig, config.Client)
 	if err != nil {
 		return nil, err
 	}

--- a/app/config.go
+++ b/app/config.go
@@ -1,5 +1,9 @@
 package app
 
+import (
+	"net/http"
+)
+
 // Config for elasticsearch-cli Application
 type Config struct {
 	User         string `mapstructure:"user"`
@@ -11,4 +15,5 @@ type Config struct {
 	Timeout      int    `mapstructure:"timeout"`
 	Insecure     bool   `mapstructure:"insecure"`
 	Headers      map[string]string
+	Client       *http.Client
 }

--- a/client/client.go
+++ b/client/client.go
@@ -9,37 +9,36 @@ import (
 	"github.com/marclop/elasticsearch-cli/utils"
 )
 
-// HTTPCallerInterface is the HTTP implementation for caller
-type HTTPCallerInterface interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
 // HTTP Wraps an http.Client with its config
 type HTTP struct {
 	Config *Config
-	caller HTTPCallerInterface
+	caller *http.Client
 }
 
 // NewHTTP is the factory function for HTTP
-func NewHTTP(config *Config, client HTTPCallerInterface) *HTTP {
-	if client == nil {
-		transport := http.DefaultTransport.(*http.Transport)
-		if transport.TLSClientConfig == nil {
-			transport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: config.insecure,
-			}
-		} else {
-			transport.TLSClientConfig.InsecureSkipVerify = config.insecure
+func NewHTTP(config *Config, client *http.Client) *HTTP {
+	if client != nil {
+		return &HTTP{
+			Config: config,
+			caller: client,
 		}
-		client = &http.Client{
-			Timeout:   config.Timeout,
-			Transport: transport,
+	}
+
+	transport := http.DefaultTransport.(*http.Transport)
+	if transport.TLSClientConfig == nil {
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: config.insecure,
 		}
+	} else {
+		transport.TLSClientConfig.InsecureSkipVerify = config.insecure
 	}
 
 	return &HTTP{
 		Config: config,
-		caller: client,
+		caller: &http.Client{
+			Timeout:   config.Timeout,
+			Transport: transport,
+		},
 	}
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -11,17 +11,10 @@ import (
 	"github.com/marclop/elasticsearch-cli/utils"
 )
 
-type emptyMockCaller struct{}
-
-func (c *emptyMockCaller) Do(*http.Request) (*http.Response, error) {
-	var err error
-	return &http.Response{}, err
-}
-
 func TestNewClient(t *testing.T) {
 	type args struct {
 		config *Config
-		client HTTPCallerInterface
+		client *http.Client
 	}
 	tests := []struct {
 		name string
@@ -32,11 +25,11 @@ func TestNewClient(t *testing.T) {
 			"NewClientHasMockClientInjected",
 			args{
 				config: &Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				client: &emptyMockCaller{},
+				client: &http.Client{},
 			},
 			NewHTTP(
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				&http.Client{},
 			),
 		},
 		{
@@ -63,7 +56,7 @@ func TestNewClient(t *testing.T) {
 func TestClient_HandleCall(t *testing.T) {
 	type fields struct {
 		config *Config
-		caller HTTPCallerInterface
+		caller *http.Client
 	}
 	type args struct {
 		method string
@@ -81,7 +74,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallHTTPByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"GET",
@@ -95,7 +90,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallHTTPSByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"https://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"GET",
@@ -109,7 +106,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallWithBodyByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"GET",
@@ -123,7 +122,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallWithHeadersByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), map[string]string{"Content-Type": "application/json"}, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"GET",
@@ -137,7 +138,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallWithAuthAndHeadersByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "marc", "marc", time.Duration(10), map[string]string{"Content-Type": "application/json"}, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"GET",
@@ -151,7 +154,9 @@ func TestClient_HandleCall(t *testing.T) {
 			"HandleCallWithInvalidMethodByEmptyMockCaller",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				NewMock(MockResponse{
+					Response: http.Response{},
+				}),
 			},
 			args{
 				"   ",
@@ -183,7 +188,7 @@ func TestClient_HandleCall(t *testing.T) {
 func TestClient_createRequest(t *testing.T) {
 	type fields struct {
 		config *Config
-		caller HTTPCallerInterface
+		caller *http.Client
 	}
 	type args struct {
 		method string
@@ -201,7 +206,7 @@ func TestClient_createRequest(t *testing.T) {
 			"createRequestWithCorrectMethod",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				&http.Client{},
 			},
 			args{
 				"GET",
@@ -223,7 +228,7 @@ func TestClient_createRequest(t *testing.T) {
 			"createRequestWithIncorrectMethod",
 			fields{
 				&Config{&hostPort{"http://localhost", 9200}, "", "", time.Duration(10), nil, false},
-				&emptyMockCaller{},
+				&http.Client{},
 			},
 			args{
 				"INVALID METHOD",

--- a/client/mock.go
+++ b/client/mock.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+// NewMock returns a pointer to http.Client with the mocked Transport.
+func NewMock(r ...MockResponse) *http.Client {
+	return &http.Client{
+		Transport: newRoundTripper(r...),
+	}
+}
+
+// newRoundTripper initializes a new roundtripper and accepts multiple Response
+// structures as variadric arguments.
+func newRoundTripper(r ...MockResponse) *RoundTripper {
+	return &RoundTripper{
+		Responses: r,
+	}
+}
+
+// RoundTripper is aimed to be used as the Transport property in an http.Client
+// in order to mock the responses that it would return in the normal execution.
+// If the number of responses that are mocked are not enough, an error with the
+// request iteration ID, method and full URL is returned.
+type RoundTripper struct {
+	Responses []MockResponse
+
+	iteration int32
+	mu        sync.RWMutex
+}
+
+// MockResponse Wraps the response of the RoundTrip.
+type MockResponse struct {
+	Response http.Response
+	Error    error
+}
+
+// Add accepts multiple Response structures as variadric arguments and appends
+// those to the current list of Responses.
+func (rt *RoundTripper) Add(res ...MockResponse) *RoundTripper {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	rt.Responses = append(rt.Responses, res...)
+	return rt
+}
+
+// RoundTrip executes a single HTTP transaction, returning
+// a Response for the provided Request.
+//
+// RoundTrip should not attempt to interpret the response. In
+// particular, RoundTrip must return err == nil if it obtained
+// a response, regardless of the response's HTTP status code.
+// A non-nil err should be reserved for failure to obtain a
+// response. Similarly, RoundTrip should not attempt to
+// handle higher-level protocol details such as redirects,
+// authentication, or cookies.
+//
+// RoundTrip should not modify the request, except for
+// consuming and closing the Request's Body. RoundTrip may
+// read fields of the request in a separate goroutine. Callers
+// should not mutate or reuse the request until the Response's
+// Body has been closed.
+//
+// RoundTrip must always close the body, including on errors,
+// but depending on the implementation may do so in a separate
+// goroutine even after RoundTrip returns. This means that
+// callers wanting to reuse the body for subsequent requests
+// must arrange to wait for the Close call before doing so.
+//
+// The Request's URL and Header fields must be initialized.
+func (rt *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.RLock()
+	defer func() {
+		atomic.AddInt32(&rt.iteration, 1)
+		rt.mu.RUnlock()
+	}()
+
+	var iteration = atomic.LoadInt32(&rt.iteration)
+	if int(iteration) > len(rt.Responses)-1 {
+		return nil, fmt.Errorf(
+			"failed to obtain response in iteration %d: %s %s",
+			iteration+1, req.Method, req.URL,
+		)
+	}
+
+	// Consume and close the body.
+	if req.Body != nil {
+		ioutil.ReadAll(req.Body)
+		req.Body.Close()
+	}
+
+	r := rt.Responses[iteration]
+	if r.Error != nil {
+		return nil, r.Error
+	}
+
+	return &r.Response, nil
+}
+
+// NewStringBody creates an io.ReadCloser from a string.
+func NewStringBody(b string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(b))
+}
+
+// NewByteBody creates an io.ReadCloser from a slice of bytes.
+func NewByteBody(b []byte) io.ReadCloser {
+	return ioutil.NopCloser(bytes.NewReader(b))
+}
+
+// NewStructBody creates an io.ReadCloser from a structure that is attempted
+// to be encoded into JSON. In case of failure, it panics.
+func NewStructBody(i interface{}) io.ReadCloser {
+	var b = new(bytes.Buffer)
+	if err := json.NewEncoder(b).Encode(i); err != nil {
+		panic(fmt.Sprintf("Failed to json.Encode structure %+v", i))
+	}
+	return ioutil.NopCloser(b)
+}


### PR DESCRIPTION
This change adds a field in the config so that an http.Client can be
specified as part of the configuration. Also removes the old interface
in favour of the direct usage of *http.Client

Signed-off-by: Marc Lopez <marc5.12@outlook.com>